### PR TITLE
Check whether read stream is empty before calling stream_select()

### DIFF
--- a/src/whois.client.php
+++ b/src/whois.client.php
@@ -194,9 +194,12 @@ class WhoisClient {
 
 			while (!feof($ptr))
 				{
-				if (stream_select($r,$null,$null,$this->STIMEOUT))
+				if (!empty($r))
 					{
-					$raw .= fgets($ptr, $this->BUFFER);
+					if (stream_select($r,$null,$null,$this->STIMEOUT))
+						{
+						$raw .= fgets($ptr, $this->BUFFER);
+						}
 					}
 
 				if (time()-$start > $this->STIMEOUT)


### PR DESCRIPTION
Fixes "stream_select(): No stream arrays were passed in" warning
