### PR TITLE
Parse domain.sponsor in "ru" and "su" handlers

### DIFF
--- a/src/whois.ru.php
+++ b/src/whois.ru.php
@@ -36,6 +36,7 @@ class ru_handler
 		{
 		$items = array(
                   'domain:' => 'domain.name',
+                  'registrar:' => 'domain.sponsor',
                   'state:' => 'domain.status',
                   'nserver:' => 'domain.nserver.',
                   'source:' => 'domain.source',

--- a/src/whois.su.php
+++ b/src/whois.su.php
@@ -36,6 +36,7 @@ class su_handler
 		{
 		$items = array(
                   'domain:' => 'domain.name',
+                  'registrar:' => 'domain.sponsor',
                   'state:' => 'domain.status',
                   'person:' => 'owner.name',
                   'phone:' => 'owner.phone',


### PR DESCRIPTION
Thanks in advance.
By the way, what's difference between `domain.sponsor` and `domain.registrar` (https://github.com/phpWhois/phpWhois/blob/master/src/whois.eu.php#L43)?
