### PR TITLE
Fix .be registered status recognition

### DIFF
--- a/src/whois.be.php
+++ b/src/whois.be.php
@@ -6,16 +6,16 @@
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; either version 2
  * of the License, or (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
- * 
+ *
  * @link http://phpwhois.pw
  * @copyright Copyright (C)1999,2005 easyDNS Technologies Inc. & Mark Jeftovic
  * @copyright Maintained by David Saez
@@ -50,7 +50,7 @@ class be_handler {
 
         $r['regrinfo'] = get_blocks($data['rawdata'], $items);
 
-        if ($r['regrinfo']['domain']['status'] == 'REGISTERED') {
+        if ($r['regrinfo']['domain']['status'] != 'AVAILABLE') {
             $r['regrinfo']['registered'] = 'yes';
             $r['regrinfo'] = get_contacts($r['regrinfo'], $trans);
 


### PR DESCRIPTION
For .be domains the $result['regrinfo']['registered'] was always resulting in "no", even when the domain is registered.
The status can be either AVAILABLE, NOT AVAILABLE or QUARANTINE. Therefore, the best way to check if the domain is registered is to check the status is not 'AVAILABLE'
