### PR TITLE
Add support for .church tld

### DIFF
--- a/src/Whois.php
+++ b/src/Whois.php
@@ -214,7 +214,7 @@ class Whois extends WhoisClient
                 }
 
                 // Regular handler exists for the tld ?
-                if (file_exists('whois.' . $htld . '.php')) {
+                if (file_exists(dirname( __FILE__ ) . '/whois.' . $htld . '.php')) {
                     $handler = $htld;
                     break;
                 }

--- a/src/whois.church.php
+++ b/src/whois.church.php
@@ -1,0 +1,100 @@
+<?php
+/*
+Whois.php        PHP classes to conduct whois queries
+
+Copyright (C)1999,2005 easyDNS Technologies Inc. & Mark Jeftovic
+
+Maintained by David Saez
+
+For the most recent version of this package visit:
+
+http://www.phpwhois.org
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+if (!defined('__CHURCH_HANDLER__'))
+	define('__CHURCH_HANDLER__', 1);
+
+require_once('whois.parser.php');
+
+class church_handler
+{
+	function parse($data_str, $query)
+	{
+		$items = array(
+			'owner' => 'Contact Type:            registrant',
+			'admin' => 'Contact Type:            admin',
+			'tech' => 'Contact Type:            tech',
+			'billing' => 'Contact Type:            billing',
+			'domain.name' => 'Domain Name:',
+			'domain.handle' => 'Domain ID:',
+			'domain.expires' => 'Registry Expiry Date:',
+			'domain.created' => 'Creation Date:',
+			'domain.changed' => 'Updated Date:',
+			'domain.status' => 'Domain Status:',
+			'domain.sponsor' => 'Sponsoring Registrar:',
+			'domain.nserver.' => 'Name Server:'
+		);
+		
+		$translate = array(
+			'Contact ID:' => 'handle',
+			'Name:' => 'name',
+			'Organisation:' => 'organization',
+			'Street 1:' => 'address.street.0',
+			'Street 2:' => 'address.street.1',
+			'Street 3:' => 'address.street.2',
+			'City:' => 'address.city',
+			'State/Province:' => 'address.state',
+			'Postal code:' => 'address.pcode',
+			'Country:' => 'address.country',
+			'Voice:' => 'phone',
+			'Fax:' => 'fax',
+			'Email:' => 'email'
+		);
+		
+		$blocks = get_blocks($data_str['rawdata'], $items);
+		
+		$r = array();
+		if (isset($blocks['domain'])) {
+			$r['regrinfo']['domain'] = format_dates($blocks['domain'], 'dmy');
+			$r['regrinfo']['registered'] = 'yes';
+			
+			if (isset($blocks['owner'])) {
+				$r['regrinfo']['owner'] = generic_parser_b($blocks['owner'], $translate,'dmy', false);
+				
+				if (isset($blocks['tech']))
+					$r['regrinfo']['tech'] = generic_parser_b($blocks['tech'], $translate,'dmy', false);
+				
+				if (isset($blocks['admin']))
+					$r['regrinfo']['admin'] = generic_parser_b($blocks['admin'], $translate,'dmy', false);
+				
+				if (isset($blocks['billing']))
+					$r['regrinfo']['billing'] = generic_parser_b($blocks['billing'], $translate,'dmy', false);
+			} else {
+				$r['regrinfo']['owner'] = generic_parser_b($data_str['rawdata'], $translate, 'dmy', false);
+			}
+		} else {
+			$r['regrinfo']['registered'] = 'no';
+		}
+		
+		$r['regyinfo'] = array(
+			'referrer' => 'http://www.donuts.domains',
+			'registrar' => '.church registry'
+		);
+		return $r;
+	}
+}
+


### PR DESCRIPTION
This adds a handler for the .church tld and ensures that the `file_exists()` check for handlers is called on a full path rather than a relative path. This works around issues where the `getcwd()` isn't the current directory.
