### PR TITLE
Checking for handlers now uses relative path.

### DIFF
--- a/src/Whois.php
+++ b/src/Whois.php
@@ -214,7 +214,7 @@ class Whois extends WhoisClient
                 }
 
                 // Regular handler exists for the tld ?
-                if (file_exists('whois.' . $htld . '.php')) {
+                if (file_exists(__DIR__ . '/whois.' . $htld . '.php')) {
                     $handler = $htld;
                     break;
                 }


### PR DESCRIPTION
Changed so that handlers can be found even if the current directory has been changed.
