### PR TITLE
utf8_encode output if it is invalid utf-8

### DIFF
--- a/src/WhoisClient.php
+++ b/src/WhoisClient.php
@@ -222,7 +222,7 @@ class WhoisClient
                 }
             }
 
-            if (array_key_exists($this->query['server'], $this->NON_UTF8)) {
+            if (array_key_exists($this->query['server'], $this->NON_UTF8) || !mb_check_encoding($raw, 'UTF-8')) {
                 $raw = utf8_encode($raw);
             }
 


### PR DESCRIPTION
Using phpWhois output is cumbersome otherwise, because the invalid utf-8 will break json_encode etc. downstream. The result may be gibberish anyway but that can't really be helped, and valid utf-8 gibberish is better than invalid utf-8.
