### PR TITLE
Fix: Parsing empty lines in ip_handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "mso/idna-convert": "~1.1"
+        "mso/idna-convert": "~0.9"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.1"

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "require": {
         "php": ">=5.3.0",
-        "mso/idna-convert": "*"
+        "mso/idna-convert": "~1.1"
     },
     "require-dev": {
         "phpunit/phpunit": "4.4.1"

--- a/src/Whois.php
+++ b/src/Whois.php
@@ -23,6 +23,7 @@
  */
 
 namespace phpWhois;
+use Mso\IdnaConvert\IdnaConvert;
 
 /**
  * phpWhois main class
@@ -75,7 +76,7 @@ class Whois extends WhoisClient
 
         $query = trim($query);
 
-        $idn = new \idna_convert();
+        $idn = new IdnaConvert();
 
         if ($is_utf) {
             $query = $idn->encode($query);

--- a/src/Whois.php
+++ b/src/Whois.php
@@ -23,7 +23,6 @@
  */
 
 namespace phpWhois;
-use Mso\IdnaConvert\IdnaConvert;
 
 /**
  * phpWhois main class
@@ -76,7 +75,7 @@ class Whois extends WhoisClient
 
         $query = trim($query);
 
-        $idn = new IdnaConvert();
+        $idn = new \idna_convert();
 
         if ($is_utf) {
             $query = $idn->encode($query);

--- a/src/whois.ip.php
+++ b/src/whois.ip.php
@@ -85,6 +85,8 @@ class ip_handler extends WhoisClient {
             $found = false;
 
             foreach ($rwdata as $line) {
+                if (strstr($line,'CIDR')){
+                }
                 if (!strncmp($line, 'American Registry for Internet Numbers', 38))
                     continue;
 

--- a/src/whois.ip.php
+++ b/src/whois.ip.php
@@ -95,21 +95,24 @@ class ip_handler extends WhoisClient {
 
                 if ($p !== false) {
                     $net = strtok(substr($line, $p + 1), ') ');
-                    list($low, $high) = explode('-', str_replace(' ', '', substr($line, $p + strlen($net) + 3)));
+                    $clearedLine = str_replace(' ', '', substr($line, $p + strlen($net) + 3));
+                    if ($clearedLine !== '') {
+                        list($low, $high) = explode('-', str_replace(' ', '', substr($line, $p + strlen($net) + 3)));
 
-                    if (!isset($done[$net]) && $ip >= ip2long($low) && $ip <= ip2long($high)) {
-                        $owner = substr($line, 0, $p - 1);
+                        if (!isset($done[$net]) && $ip >= ip2long($low) && $ip <= ip2long($high)) {
+                            $owner = substr($line, 0, $p - 1);
 
-                        if (!empty($this->REGISTRARS['owner'])) {
-                            $this->handle_rwhois($this->REGISTRARS['owner'], $query);
-                            break 2;
-                        } else {
-                            $this->query['args'] = 'n ' . $net;
-                            $presults[] = $this->getRawData($net);
-                            $done[$net] = 1;
+                            if (!empty($this->REGISTRARS['owner'])) {
+                                $this->handle_rwhois($this->REGISTRARS['owner'], $query);
+                                break 2;
+                            } else {
+                                $this->query['args'] = 'n '.$net;
+                                $presults[] = $this->getRawData($net);
+                                $done[$net] = 1;
+                            }
                         }
+                        $found = true;
                     }
-                    $found = true;
                 }
             }
 

--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -317,7 +317,7 @@ function generic_parser_b($rawdata, $items = array(), $dateformat = 'mdy', $hasr
             'Zone Email:' => 'zone.email'
         );
 
-    $r = '';
+    $r = [];
     $disok = true;
 
     while (list($key, $val) = each($rawdata)) {

--- a/src/whois.parser.php
+++ b/src/whois.parser.php
@@ -317,7 +317,7 @@ function generic_parser_b($rawdata, $items = array(), $dateformat = 'mdy', $hasr
             'Zone Email:' => 'zone.email'
         );
 
-    $r = [];
+    $r = array();
     $disok = true;
 
     while (list($key, $val) = each($rawdata)) {

--- a/tests/ip_handlerTest.php
+++ b/tests/ip_handlerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Created by PhpStorm.
+ * User: dreamlex
+ * Date: 22.08.16
+ * Time: 12:35
+ */
+class ip_handlerTest extends PHPUnit_Framework_TestCase
+{
+    public function testParseIp()
+    {
+        $ipHandler = new \phpWhois\Whois();
+        $result = $ipHandler->lookup('216.58.209.195');
+        self::assertTrue(is_array($result));
+    }
+}


### PR DESCRIPTION
Fixing this issue for empty lines when parsing google ips 
[Here](https://github.com/phpWhois/phpWhois/issues/8)
