### PR TITLE
Fixes deprecated PHP 4 style constructors by renaming them to __construct()

### DIFF
--- a/src/whois.client.php
+++ b/src/whois.client.php
@@ -68,7 +68,7 @@ class WhoisClient {
 	/*
 	 * Constructor function
 	 */
-	function WhoisClient () {
+	function __construct () {
 		// Load DATA array
 		@require('whois.servers.php');		
 

--- a/src/whois.idna.php
+++ b/src/whois.idna.php
@@ -91,7 +91,7 @@ class idna_convert
     var $_strict_mode    =  false;  // Behave strict or not
 
     // The constructor
-    function idna_convert($options = false)
+    function __construct($options = false)
     {
         $this->slast = $this->_sbase + $this->_lcount * $this->_vcount * $this->_tcount;
         if (function_exists('file_get_contents')) {

--- a/src/whois.main.php
+++ b/src/whois.main.php
@@ -48,7 +48,7 @@ class Whois extends WhoisClient
 	/*
 	 * Constructor function
 	 */
-	function Whois()
+	function __construct()
 		{
 		// Load DATA array
 		@require('whois.servers.php');


### PR DESCRIPTION
While using phpWhois 4-stable with PHP 7.0.8, PHP returns the following deprecation warnings because old PHP 4 style constructors are used. 

```
PHP Deprecated: Methods with the same name as their class will not be constructors 
in a future version of PHP; Whois has a deprecated constructor in 
/home/code/phpwhois/src/whois.main.php on line 31

PHP Deprecated:  Methods with the same name as their class will not be constructors 
in a future version of PHP; WhoisClient has a deprecated constructor in 
/home/code/phpwhois/src/whois.client.php on line 30

PHP Deprecated:  Methods with the same name as their class will not be constructors 
in a future version of PHP; idna_convert has a deprecated constructor in 
/home/code/phpwhois/src/whois.idna.php on line 54
```

The PR fixes this by renaming the mentioned deprecated constructors to `__construct`. 

Since the minimum required PHP version for this phpWhois version is 5.3, and because PHP 5.3 supports constructors named `__construct`, this won't break compatibility with older PHP versions.
