### PR TITLE
Fix failed to open stream in deep whois

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
-    "name": "phpwhois/phpwhois",
+    "name": "Adlaran/phpwhois",
     "description": "phpWhois - library for querying whois services and parsing results. Based on phpwhois.org",
     "keywords": ["PHP","Whois","phpWhois"],
-    "homepage": "http://phpwhois.pw",
+    "homepage": "https://github.com/Adlaran/phpWhois",
     "type": "library",
     "license": "GPL-2.0",
     "authors": [

--- a/src/whois.client.php
+++ b/src/whois.client.php
@@ -499,7 +499,7 @@ class WhoisClient {
 				$parts = explode('.',$wserver);
 				$hname = strtolower($parts[1]);
 
-				if (($fp = @fopen('whois.gtld.'.$hname.'.php', 'r', 1)) and fclose($fp))
+				if (file_exists('whois.gtld.'.$hname.'.php'))
 					$this->Query['handler'] = $hname;
 				}
 				


### PR DESCRIPTION
Fopen in DeepWhois method fails when trying to open nonexistent file like whois.gtld.xxxx.php